### PR TITLE
Support for 'as' option on Route Groups

### DIFF
--- a/src/Controllers/APIController.php
+++ b/src/Controllers/APIController.php
@@ -79,7 +79,7 @@ class APIController extends Controller
         if (str_contains($indicator, '.') && !starts_with($indicator, '_')) {
             $indicatorArray = explode('.', $indicator);
             $this->action = last($indicatorArray);
-            $this->resource = head($indicatorArray);
+            $this->resource = $indicatorArray[count($indicatorArray) - 2];
             $this->modelBaseName = studly_case($this->resource);
 
             if ($modelName = $this->modelClass()) {


### PR DESCRIPTION
With the latest changes to support the way Laravel 5.3 deals with the prefixes in route groups the prefix is no longer a part of the route name. This can become a problem because all the resources from the 'admin' group will pollute the named routes space outside of it, which will likely cause name clashes between admin routes and non-admin routes.

If the options 'as' is setted in the route group options it's possible to 'namespace' the routes/resources bound to that group. But this will cause cms to fail as it will fetch the wrong resource. This change will fix it, allowing to use the option 'as'. 

It assumes the resource is always the second last item from the route name instead of the first one.
